### PR TITLE
Support namespaces in translation resources

### DIFF
--- a/.changeset/spicy-berries-repeat.md
+++ b/.changeset/spicy-berries-repeat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Support namespaces in translation resources

--- a/src/index.js
+++ b/src/index.js
@@ -117,47 +117,6 @@ class ShopifyFormat {
 
     return finalKeys;
   }
-
-  getResource(lng, _ns, key, options) {
-    // This is a copy of
-    // https://github.com/i18next/i18next/blob/ac4b6701c3ce9596e4eb88f5d774ca66f05d71fb/src/ResourceStore.js#L34-L56
-    // except we ignore the namespace, since Shopify's format doesn't have namespaces.
-    const keySeparator =
-      options.keySeparator === undefined
-        ? this.i18next.translator.resourceStore.options.keySeparator
-        : options.keySeparator;
-
-    const ignoreJSONStructure =
-      options.ignoreJSONStructure === undefined
-        ? this.i18next.translator.resourceStore.options.ignoreJSONStructure
-        : options.ignoreJSONStructure;
-
-    let path = [lng];
-    if (key && typeof key !== 'string') {
-      path = path.concat(key);
-    }
-    if (key && typeof key === 'string') {
-      path = path.concat(keySeparator ? key.split(keySeparator) : key);
-    }
-
-    if (lng.indexOf('.') > -1) {
-      path = lng.split('.');
-    }
-
-    const result = utils.getPath(
-      this.i18next.translator.resourceStore.data,
-      path,
-    );
-    if (result || !ignoreJSONStructure || typeof key !== 'string') {
-      return result;
-    }
-
-    return utils.deepFind(
-      this.i18next.translator.resourceStore.data[lng],
-      key,
-      keySeparator,
-    );
-  }
 }
 
 ShopifyFormat.type = 'i18nFormat';

--- a/test/shopify.spec.js
+++ b/test/shopify.spec.js
@@ -158,25 +158,27 @@ describe('shopify format', () => {
         lng: 'en',
         resources: {
           en: {
-            string: 'Hello world!',
-            string_with_interpolation:
-              'Hello {{casual_name}}! Today is {{date}}.',
-            string_with_repeated_interpolation:
-              'Hello {{casual_name}}! Hello {{casual_name}}!',
-            cardinal_pluralization: {
-              0: 'I have no cars.',
-              one: 'I have {{count}} car.',
-              other: 'I have {{count}} cars.',
-            },
-            cardinal_pluralization_with_missing_keys: {
-              other: 'I have {{count}} cars.',
-            },
-            ordinal_pluralization: {
-              ordinal: {
-                one: 'This is my {{ordinal}}st car',
-                two: 'This is my {{ordinal}}nd car',
-                few: 'This is my {{ordinal}}rd car',
-                other: 'This is my {{ordinal}}th car',
+            translation: {
+              string: 'Hello world!',
+              string_with_interpolation:
+                'Hello {{casual_name}}! Today is {{date}}.',
+              string_with_repeated_interpolation:
+                'Hello {{casual_name}}! Hello {{casual_name}}!',
+              cardinal_pluralization: {
+                0: 'I have no cars.',
+                one: 'I have {{count}} car.',
+                other: 'I have {{count}} cars.',
+              },
+              cardinal_pluralization_with_missing_keys: {
+                other: 'I have {{count}} cars.',
+              },
+              ordinal_pluralization: {
+                ordinal: {
+                  one: 'This is my {{ordinal}}st car',
+                  two: 'This is my {{ordinal}}nd car',
+                  few: 'This is my {{ordinal}}rd car',
+                  other: 'This is my {{ordinal}}th car',
+                },
               },
             },
           },
@@ -292,25 +294,27 @@ describe('shopify format', () => {
           lng: 'en',
           resources: {
             en: {
-              string: 'Hello world!',
-              string_with_interpolation:
-                'Hello {{casual_name}}! Today is {{date}}.',
-              string_with_repeated_interpolation:
-                'Hello {{casual_name}}! Hello {{casual_name}}!',
-              cardinal_pluralization: {
-                0: 'I have no cars.',
-                one: 'I have {{count}} car.',
-                other: 'I have {{count}} cars.',
-              },
-              cardinal_pluralization_with_missing_keys: {
-                other: 'I have {{count}} cars.',
-              },
-              ordinal_pluralization: {
-                ordinal: {
-                  one: 'This is my {{ordinal}}st car',
-                  two: 'This is my {{ordinal}}nd car',
-                  few: 'This is my {{ordinal}}rd car',
-                  other: 'This is my {{ordinal}}th car',
+              translation: {
+                string: 'Hello world!',
+                string_with_interpolation:
+                  'Hello {{casual_name}}! Today is {{date}}.',
+                string_with_repeated_interpolation:
+                  'Hello {{casual_name}}! Hello {{casual_name}}!',
+                cardinal_pluralization: {
+                  0: 'I have no cars.',
+                  one: 'I have {{count}} car.',
+                  other: 'I have {{count}} cars.',
+                },
+                cardinal_pluralization_with_missing_keys: {
+                  other: 'I have {{count}} cars.',
+                },
+                ordinal_pluralization: {
+                  ordinal: {
+                    one: 'This is my {{ordinal}}st car',
+                    two: 'This is my {{ordinal}}nd car',
+                    few: 'This is my {{ordinal}}rd car',
+                    other: 'This is my {{ordinal}}th car',
+                  },
                 },
               },
             },
@@ -446,25 +450,27 @@ describe('shopify format', () => {
           lng: 'en',
           resources: {
             en: {
-              string: 'Hello world!',
-              string_with_interpolation:
-                'Hello {{casual_name}}! Today is {{date}}.',
-              string_with_repeated_interpolation:
-                'Hello {{casual_name}}! Hello {{casual_name}}!',
-              cardinal_pluralization: {
-                0: 'I have no cars.',
-                one: 'I have {{count}} car.',
-                other: 'I have {{count}} cars.',
-              },
-              cardinal_pluralization_with_missing_keys: {
-                other: 'I have {{count}} cars.',
-              },
-              ordinal_pluralization: {
-                ordinal: {
-                  one: 'This is my {{ordinal}}st car',
-                  two: 'This is my {{ordinal}}nd car',
-                  few: 'This is my {{ordinal}}rd car',
-                  other: 'This is my {{ordinal}}th car',
+              translation: {
+                string: 'Hello world!',
+                string_with_interpolation:
+                  'Hello {{casual_name}}! Today is {{date}}.',
+                string_with_repeated_interpolation:
+                  'Hello {{casual_name}}! Hello {{casual_name}}!',
+                cardinal_pluralization: {
+                  0: 'I have no cars.',
+                  one: 'I have {{count}} car.',
+                  other: 'I have {{count}} cars.',
+                },
+                cardinal_pluralization_with_missing_keys: {
+                  other: 'I have {{count}} cars.',
+                },
+                ordinal_pluralization: {
+                  ordinal: {
+                    one: 'This is my {{ordinal}}st car',
+                    two: 'This is my {{ordinal}}nd car',
+                    few: 'This is my {{ordinal}}rd car',
+                    other: 'This is my {{ordinal}}th car',
+                  },
                 },
               },
             },
@@ -633,20 +639,22 @@ describe('shopify format', () => {
           lng: 'en',
           resources: {
             en: {
-              nameTitle: 'This is your name',
-              // This isn't valid syntax for app extensions, but we include it here to make sure that this plugin
-              // doesn't break things when used with react-i18next in embedded apps.
-              userMessagesUnread: {
-                one: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <6>Go to message</6>.',
-                other:
-                  'Hello <1>{{name}}</1>, you have {{count}} unread messages.  <6>Go to messages</6>.',
-              },
-              // This isn't valid syntax for app extensions, but we include it here to make sure that this plugin
-              // doesn't break things when used with react-i18next in embedded apps.
-              userMessagesUnreadExplicit: {
-                one: 'Hello <Name>{{name}}</Name>, you have {{count}} unread message. <MessagesLink>Go to message</MessagesLink>.',
-                other:
-                  'Hello <Name>{{name}}</Name>, you have {{count}} unread messages.  <MessagesLink>Go to messages</MessagesLink>.',
+              translation: {
+                nameTitle: 'This is your name',
+                // This isn't valid syntax for app extensions, but we include it here to make sure that this plugin
+                // doesn't break things when used with react-i18next in embedded apps.
+                userMessagesUnread: {
+                  one: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <6>Go to message</6>.',
+                  other:
+                    'Hello <1>{{name}}</1>, you have {{count}} unread messages. <6>Go to messages</6>.',
+                },
+                // This isn't valid syntax for app extensions, but we include it here to make sure that this plugin
+                // doesn't break things when used with react-i18next in embedded apps.
+                userMessagesUnreadExplicit: {
+                  one: 'Hello <Name>{{name}}</Name>, you have {{count}} unread message. <MessagesLink>Go to message</MessagesLink>.',
+                  other:
+                    'Hello <Name>{{name}}</Name>, you have {{count}} unread messages. <MessagesLink>Go to messages</MessagesLink>.',
+                },
               },
             },
           },


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

The i18next framework uses [namespaces](https://www.i18next.com/principles/namespaces) to allow translation keys to be split into multiple files. Even when single translation files are used and the namespace feature is ignored, the resource object uses the default `translation` namespace.

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

This pull request removes the custom `getResource` function in favour of the default behaviour, and updates the tests to assume that the default namespace `translation` exists in the resource object.

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

This will allow `i18next-shopify` to correctly access translation resources, regardless of the namespace configuration.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Unit tests

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
