### PR TITLE
Recreate patch

### DIFF
--- a/.changeset/lazy-melons-dance.md
+++ b/.changeset/lazy-melons-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Support namespaces in translation resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
-# Changelog
-
-## 0.0.3
-
-### Patch Changes
-
-- db2f198: Support namespaces in translation resources
+# Changelogg
 
 ## 0.0.2
 


### PR DESCRIPTION
### What are you trying to accomplish?
Release a new version.

0.0.3 gets this error:
"summary": "403 Forbidden - PUT https://registry.npmjs.org/@shopify%2fi18next-shopify - You cannot publish over the previously published versions: 0.0.3.",

My guess is that there is an un-published version 0.0.3.

### What approach did you choose and why?
Re-create patch changeset to bump version to 0.0.4
