### PR TITLE
Add support for returnObjects: true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,11 @@ class ShopifyFormat {
   parse(res, options) {
     // const hadSuccessfulLookup = info && info.resolved && info.resolved.res;
 
+    // returnObjects parameter can cause objects to be resolved, rather than a single string
+    if (typeof res === 'object') {
+      return res;
+    }
+
     // Interpolations
     const matches = res.match(MUSTACHE_FORMAT);
     if (!matches) {

--- a/test/shopify_format_with_react_i18next.spec.js
+++ b/test/shopify_format_with_react_i18next.spec.js
@@ -44,6 +44,9 @@ describe('shopify format with react-i18next (t)', () => {
                   other: 'This is my {{ordinal}}th car',
                 },
               },
+              nested_level_1: {
+                nested_level_2: 'Nested content',
+              },
             },
           },
         },
@@ -162,6 +165,15 @@ describe('shopify format with react-i18next (t)', () => {
         ordinal: 2,
       }),
     ).toBe('This is my 2st car');
+  });
+
+  it('handles returnObjects: true', () => {
+    const {result} = renderHook(() => useTranslation('translation'));
+    const {t} = result.current;
+
+    expect(t('nested_level_1', {returnObjects: true})).toStrictEqual({
+      nested_level_2: 'Nested content',
+    });
   });
 });
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #171

Add support for `{returnObjects: true}` parameter of `t()`


### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
