### PR TITLE
Format count and ordinal as number

### DIFF
--- a/.changeset/five-trees-sell.md
+++ b/.changeset/five-trees-sell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Supports formatting of count and ordinal values as numbers

--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,18 @@ class ShopifyFormat {
     let interpolated = res;
     matches.forEach((match) => {
       const interpolation_key = match.replace(MUSTACHE_FORMAT, '$1');
-      const value =
-        interpolation_key === 'ordinal'
-          ? options.count || options.ordinal
-          : options[interpolation_key];
+
+      let value;
+      if (interpolation_key === 'ordinal') {
+        value = options.count || options.ordinal;
+      } else if (interpolation_key === 'count') {
+        value = new Intl.NumberFormat(this.i18next.resolvedLanguage).format(
+          options[interpolation_key],
+        );
+      } else {
+        value = options[interpolation_key];
+      }
+
       if (value !== undefined) {
         interpolated = utils.replaceValue(interpolated, match, value);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -47,15 +47,17 @@ class ShopifyFormat {
     matches.forEach((match) => {
       const interpolation_key = match.replace(MUSTACHE_FORMAT, '$1');
 
-      let value;
-      if (interpolation_key === 'ordinal') {
-        value = options.count || options.ordinal;
-      } else if (interpolation_key === 'count') {
+      let value =
+        interpolation_key === 'ordinal'
+          ? options.count || options.ordinal
+          : options[interpolation_key];
+
+      // Cardinal and Ordinal pluralizations should be formatted according to their locale
+      // eg. "1,234,567th" instead of "1234567th"
+      if (interpolation_key === 'ordinal' || interpolation_key === 'count') {
         value = new Intl.NumberFormat(this.i18next.resolvedLanguage).format(
-          options[interpolation_key],
+          value,
         );
-      } else {
-        value = options[interpolation_key];
       }
 
       if (value !== undefined) {

--- a/test/shopify_format.spec.js
+++ b/test/shopify_format.spec.js
@@ -246,6 +246,12 @@ describe('shopify format', () => {
       ).toBe('This is my 4th car');
     });
 
+    it('formats ordinal pluralization according to locale format', () => {
+      expect(
+        i18next.t('ordinal_pluralization', {count: 5000, ordinal: true}),
+      ).toBe('This is my 5,000th car');
+    });
+
     it('handles ordinal pluralization lookups (using ordinal: <number>)', () => {
       expect(i18next.t('ordinal_pluralization', {ordinal: 1})).toBe(
         'This is my 1st car',

--- a/test/shopify_format.spec.js
+++ b/test/shopify_format.spec.js
@@ -205,6 +205,12 @@ describe('shopify format', () => {
       );
     });
 
+    it('formats cardinal pluralization according to locale format', () => {
+      expect(i18next.t('cardinal_pluralization', {count: 5000})).toBe(
+        'I have 5,000 cars.',
+      );
+    });
+
     it('falls back to the `other` key if the proper cardinal pluralization key is missing', () => {
       expect(
         // A count of 1 in `en` should use the `one` key, but it's missing.


### PR DESCRIPTION
### What are you trying to accomplish?
Fixes  https://github.com/Shopify/i18next-shopify/issues/180

Implements numeric formatting by locale in order to support rendering of the `count` and `ordinal` values as numbers.


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
