### PR TITLE
Handle interpolation when returnObjects=true

### DIFF
--- a/.changeset/thin-apes-provide.md
+++ b/.changeset/thin-apes-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Interpolation when returnObjects:true

--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,18 @@ class ShopifyFormat {
   parse(res, options) {
     // const hadSuccessfulLookup = info && info.resolved && info.resolved.res;
 
-    // returnObjects parameter can cause objects to be resolved, rather than a single string
-    if (typeof res === 'object') {
+    if (res === null) {
       return res;
+    }
+
+    // returnObjects parameter can cause objects to be resolved, rather than a single string
+    // Perform parsing/interpolation on each of it's values
+    if (typeof res === 'object') {
+      const newRes = {};
+      for (const [key, value] of Object.entries(res)) {
+        newRes[key] = this.parse(value, options);
+      }
+      return newRes;
     }
 
     // Interpolations

--- a/test/shopify_format_with_react_i18next.spec.js
+++ b/test/shopify_format_with_react_i18next.spec.js
@@ -47,6 +47,10 @@ describe('shopify format with react-i18next (t)', () => {
               nested_level_1: {
                 nested_level_2: 'Nested content',
               },
+              nested_with_params: {
+                formal_greeting: 'Greetings {name}',
+                informal_greeting: 'Sup {name}',
+              },
             },
           },
         },
@@ -189,6 +193,18 @@ describe('shopify format with react-i18next (t)', () => {
 
     expect(t('nested_level_1', {returnObjects: true})).toStrictEqual({
       nested_level_2: 'Nested content',
+    });
+  });
+
+  it('handles nested interpolation with returnObjects: true', () => {
+    const {result} = renderHook(() => useTranslation('translation'));
+    const {t} = result.current;
+
+    expect(
+      t('nested_with_params', {name: 'Joe', returnObjects: true}),
+    ).toStrictEqual({
+      formal_greeting: 'Greetings Joe',
+      informal_greeting: 'Sup Joe',
     });
   });
 });


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/Shopify/i18next-shopify/issues/182

Provides interpolation on the tree that is returned when setting `returnObjects: true` in order to match the usual behaviour of `i18next`.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
