### PR TITLE
Don't format count/ordinal as a number if they aren't one

### DIFF
--- a/.changeset/breezy-pugs-provide.md
+++ b/.changeset/breezy-pugs-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Only format count/ordinal as number if they are one

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,11 @@ class ShopifyFormat {
 
       // Cardinal and Ordinal pluralizations should be formatted according to their locale
       // eg. "1,234,567th" instead of "1234567th"
-      if (interpolation_key === 'ordinal' || interpolation_key === 'count') {
+      // However `count` and `ordinal` can also be used as a non-plural variable
+      if (
+        (interpolation_key === 'ordinal' || interpolation_key === 'count') &&
+        typeof value === 'number'
+      ) {
         value = new Intl.NumberFormat(this.i18next.resolvedLanguage).format(
           value,
         );

--- a/test/shopify_format.spec.js
+++ b/test/shopify_format.spec.js
@@ -144,6 +144,7 @@ describe('shopify format', () => {
                 'Hello {{casual_name}}! Today is {{date}}.',
               string_with_repeated_interpolation:
                 'Hello {{casual_name}}! Hello {{casual_name}}!',
+              non_plural_count: 'The count is {count}.',
               cardinal_pluralization: {
                 0: 'I have no cars.',
                 one: 'I have {{count}} car.',
@@ -208,6 +209,12 @@ describe('shopify format', () => {
     it('formats cardinal pluralization according to locale format', () => {
       expect(i18next.t('cardinal_pluralization', {count: 5000})).toBe(
         'I have 5,000 cars.',
+      );
+    });
+
+    it('does not format count as plural if passed as string', () => {
+      expect(i18next.t('non_plural_count', {count: '5_000'})).toBe(
+        'The count is 5_000.',
       );
     });
 


### PR DESCRIPTION
### What are you trying to accomplish?

Typically we'll pass `count` and `ordinal` as a number because they're used in cardinal and ordinal pluralization, but it's also possible to pass them as a string in translations that use a `{count}` or `{ordinal}` variable which are not using pluralization such as

```
{ greeting: "Hello {name}, you are {count} years old." }
```

In this case, we should use `formatNumber` on count, but only if it _is_ a number. If the developer has already formatted it we should avoid formatting it again to avoid turning a string into `NaN`


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
