### PR TITLE
Only insert key on react elements

### DIFF
--- a/.changeset/breezy-poets-count.md
+++ b/.changeset/breezy-poets-count.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Don't break objects when inserting key prop

--- a/.changeset/breezy-pugs-provide.md
+++ b/.changeset/breezy-pugs-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Only format count/ordinal as number if they are one

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "https://github.com/Shopify/i18next-shopify"
   },
+  "peerDependencies": {
+    "react": "*"
+  },
   "devDependencies": {
     "@babel/cli": "^7.15.0",
     "@babel/core": "^7.15.0",

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,11 @@ class ShopifyFormat {
 
       // Cardinal and Ordinal pluralizations should be formatted according to their locale
       // eg. "1,234,567th" instead of "1234567th"
-      if (interpolation_key === 'ordinal' || interpolation_key === 'count') {
+      // However `count` and `ordinal` can also be used as a non-plural variable
+      if (
+        (interpolation_key === 'ordinal' || interpolation_key === 'count') &&
+        typeof value === 'number'
+      ) {
         value = new Intl.NumberFormat(this.i18next.resolvedLanguage).format(
           value,
         );

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const {isValidElement, cloneElement} = require('react');
+
 const arr = [];
 const each = arr.forEach;
 
@@ -34,10 +36,9 @@ export function replaceValue(interpolated, pattern, replacement) {
       if (split.length !== 1 && typeof replacement === 'object') {
         // Return array w/ the replacement
 
-        // React elements within arrays need a key prop
-        if (!replacement.key) {
+        if (!replacement.key && isValidElement(replacement)) {
           // eslint-disable-next-line no-param-reassign
-          replacement = {...replacement, key: pattern.toString()};
+          replacement = cloneElement(replacement, {key: pattern.toString()});
         }
 
         return [split[0], replacement, split[1]].flat();

--- a/test/shopify_format.spec.js
+++ b/test/shopify_format.spec.js
@@ -144,6 +144,7 @@ describe('shopify format', () => {
                 'Hello {{casual_name}}! Today is {{date}}.',
               string_with_repeated_interpolation:
                 'Hello {{casual_name}}! Hello {{casual_name}}!',
+              non_plural_count: 'The count is {count}.',
               cardinal_pluralization: {
                 0: 'I have no cars.',
                 one: 'I have {{count}} car.',
@@ -208,6 +209,12 @@ describe('shopify format', () => {
     it('formats cardinal pluralization according to locale format', () => {
       expect(i18next.t('cardinal_pluralization', {count: 5000})).toBe(
         'I have 5,000 cars.',
+      );
+    });
+
+    it('does not format count as plural if passed as string', () => {
+      expect(i18next.t('non_plural_count', {count: '5_000'})).toBe(
+        'The count is 5_000.',
       );
     });
 

--- a/test/shopify_format_with_react_i18next.spec.js
+++ b/test/shopify_format_with_react_i18next.spec.js
@@ -207,6 +207,29 @@ describe('shopify format with react-i18next (t)', () => {
       informal_greeting: 'Sup Joe',
     });
   });
+
+  it('matches expect.anything() in interpolated variables', () => {
+    const {result} = renderHook(() => useTranslation('translation'));
+    const {t} = result.current;
+
+    expect(
+      t('string_with_single_mustache', {
+        name: <strong>Joe</strong>,
+      }),
+    ).toStrictEqual(
+      t('string_with_single_mustache', {name: expect.anything()}),
+    );
+  });
+
+  it('accepts arrays as interpolated variables', () => {
+    const {result} = renderHook(() => useTranslation('translation'));
+    const {t} = result.current;
+    expect(
+      t('string_with_single_mustache', {
+        name: ['Joe', 'Jane'],
+      }),
+    ).toStrictEqual(['Hello ', 'Joe', 'Jane', '!']);
+  });
 });
 
 describe('with react-i18next (Trans)', () => {


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/Shopify/i18next-shopify/issues/187

We should only be inserting a `key` prop into the replacement object if it is a valid React element. And we should use `cloneElement` to do so to avoid breaking the original object in edge cases such as arrays.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
