### PR TITLE
Change `require` statement to `import` statement

### DIFF
--- a/.changeset/fast-lies-invite.md
+++ b/.changeset/fast-lies-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Resolve Vite production issues by replacing `require` statement with `import`

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,6 +38,7 @@ const config = {
     copy({targets: [{src: './index.d.ts', dest: 'dist/types'}]}),
   ].concat(compress ? terser() : []),
   output,
+  external: ['react'],
 };
 
 export default config;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-const {isValidElement, cloneElement} = require('react');
+import {isValidElement, cloneElement} from 'react';
 
 const arr = [];
 const each = arr.forEach;


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

The `require` statement here is causing problems in production for Shopify apps using `@shopify/i18next-shopify` and Vite builds:
- https://community.shopify.com/c/shopify-cli-and-tools/shopify-app-build-issue/td-p/2236320
- https://stackoverflow.com/questions/77148072/uncaught-referenceerror-require-is-not-defined-shopify-php-react-browser-issue
- https://stackoverflow.com/questions/77136986/vite-config-started-failing-on-build-for-shopify-app

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

Change the `require` statement to an `import` statement.

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

Resolve production issues for Shopify developers and prevent unnecessary workarounds.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
