### PR TITLE
Support for `i18next` v24

### DIFF
--- a/.changeset/poor-dots-fry.md
+++ b/.changeset/poor-dots-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Update to support i18next v24

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class ShopifyFormat {
     );
 
     if (needsPluralHandling) {
-      if (!this.i18next.translator.pluralResolver.shouldUseIntlApi()) {
+      if (!Intl) {
         throw new Error(
           'Error: The application was unable to use the Intl API. This may be due to a missing or incomplete polyfill.',
         );


### PR DESCRIPTION
### What are you trying to accomplish?

Required changes to support [i18next v24](https://www.i18next.com/misc/migration-guide#v23.x.x-to-v24.0.0).

### What approach did you choose and why?

The latest version of i18next [v24] makes the [Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) required in all cases. This PR changes the call from `i18next.translator.pluralResolver.shouldUseIntlApi` (which was removed) to a straight check on `Intl` which matches the [i18next implementation](https://github.com/i18next/i18next/blob/83a9dfab01986c9b4289019cce18196f300c6ee3/src/PluralResolver.js#L51-L61).

### What should reviewers focus on?

It seems like we require `Intl` or a polyfill already, so this shouldn't qualify as a breaking change. Any consequences we might be missing?

### The impact of these changes

The Intl API is already required, but this enforces it more directly in this library. It is [supported in all major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#browser_compatibility) with polyfills available for supporting older browsers.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
