### PR TITLE
Support for `i18next` v24

### DIFF
--- a/.changeset/poor-dots-fry.md
+++ b/.changeset/poor-dots-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/i18next-shopify': patch
+---
+
+Update to support i18next v24

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-prettier": "^5.0.0-alpha.2",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-testing-library": "^6.0.1",
-    "i18next": "^23.1.0",
+    "i18next": "^24.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "npm-run-all": "^4.1.5",

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class ShopifyFormat {
     );
 
     if (needsPluralHandling) {
-      if (!this.i18next.translator.pluralResolver.shouldUseIntlApi()) {
+      if (!Intl) {
         throw new Error(
           'Error: The application was unable to use the Intl API. This may be due to a missing or incomplete polyfill.',
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,10 +3998,10 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-i18next@^23.1.0:
-  version "23.16.8"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.16.8.tgz#3ae1373d344c2393f465556f394aba5a9233b93a"
-  integrity sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==
+i18next@^24.0.0:
+  version "24.0.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-24.0.0.tgz#26c80a064da655013acfca2d750bdf7a342860bb"
+  integrity sha512-ORGCwMrXxpmB/AljFbGEe0UK/9Pz6umb9aZgLZ9qJGE+kjKhlnLj423WX2mt+N0MlEJ78pQXFMBmeMzrkLxriQ==
   dependencies:
     "@babel/runtime" "^7.23.2"
 


### PR DESCRIPTION
### What are you trying to accomplish?

Required changes to support [i18next v24](https://www.i18next.com/misc/migration-guide#v23.x.x-to-v24.0.0).

### What approach did you choose and why?

The latest version of i18next [v24] makes the [Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) required in all cases. This PR changes the call from `i18next.translator.pluralResolver.shouldUseIntlApi` (which was removed) to a straight check on `Intl` which matches the [i18next implementation](https://github.com/i18next/i18next/blob/83a9dfab01986c9b4289019cce18196f300c6ee3/src/PluralResolver.js#L51-L61).

### What should reviewers focus on?

It seems like we require `Intl` or a polyfill already, so this shouldn't qualify as a breaking change. Any consequences we might be missing?

### The impact of these changes

The Intl API is already required, but this enforces it more directly in this library. It is [supported in all major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#browser_compatibility) with polyfills available for supporting older browsers.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
